### PR TITLE
remove iterator

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11


### PR DESCRIPTION
This handles the resource leak issues by consuming the entire iterator as soon as possible and closing the input stream. This assumes that the iterator is not holding more data than can fit in memory. 